### PR TITLE
Changes to enable use in EvoPro

### DIFF
--- a/run/af3_utils.py
+++ b/run/af3_utils.py
@@ -165,8 +165,10 @@ def get_af3_parser() -> FileArgumentParser:
 def get_af3_args(arg_file: Optional[str] = None) -> Dict[str, Any]:
     """Reformats args and returns a dictionary parsed args.
 
-    If no arg_file is provided, then arguments are assumed to come from the
-    command line.
+    Args:
+        arg_file (str, optional): Path to the file containing argument key-
+            value pairs. If None, then arguments are assumed to come from the
+            command line. Defaults to None.
 
     Returns:
         Dict[str, Any]: Dictionary mapping argument key to argument value.

--- a/run/af3_utils.py
+++ b/run/af3_utils.py
@@ -208,7 +208,7 @@ def set_json_defaults(json_str: str, run_mmseqs: bool = False, output_dir: str =
     if isinstance(raw_json, list):
         # AlphaFold Server JSON.
         # Don't apply the defaults to this format.
-        pass
+        return raw_json
     else:
         # These defaults may need changed with future AF3 updates.
         set_if_absent(raw_json, 'dialect', 'alphafold3')
@@ -254,18 +254,16 @@ def set_json_defaults(json_str: str, run_mmseqs: bool = False, output_dir: str =
                 set_if_absent(sequence['protein'], 'pairedMsa', '')
             elif 'rna' in sequence:
                 set_if_absent(sequence['rna'], 'unpairedMsa', '')
-                
-        # Convert the dictionary back to a str
-        json_str = json.dumps(raw_json)
     
-    return json_str
+    return raw_json
 
 
-def load_fold_inputs_from_path(json_path: pathlib.Path, run_mmseqs: bool = False, output_dir: str = '', max_template_date: str = '3000-01-01') -> Sequence[Input]:
-    """Loads multiple fold inputs from a JSON path.
+def load_fold_inputs_from_path(json_path: Union[pathlib.Path, str], run_mmseqs: bool = False, output_dir: str = '', max_template_date: str = '3000-01-01') -> Sequence[Input]:
+    """Loads multiple fold inputs from a JSON path (or string of a JSON).
 
     Args:
-        json_path (pathlib.Path): Path to the JSON file
+        json_path (Union[pathlib.Path, str]): Either the path to the JSON file or the string 
+            corresponding to it.
         run_mmseqs (bool, optional): Whether to run MMseqs on protein chains. Defaults to False.
         output_dir (str, optional): Place that'll store MMseqs MSAs and templates. Defaults to ''.
         max_template_date (str, optional): Maximum date for a template to be used. Defaults to '3000-01-01'.
@@ -277,24 +275,47 @@ def load_fold_inputs_from_path(json_path: pathlib.Path, run_mmseqs: bool = False
         Sequence[Input]: A list of folding inputs.
     """
     # Update the json defaults before parsing it.
-    with open(json_path, 'r') as f:
-        json_str = f.read()
-    json_str = set_json_defaults(json_str, run_mmseqs, output_dir, max_template_date)
-    
+    if not isinstance(json_path, str):
+        with open(json_path, 'r') as f:
+            json_str = f.read()
+    else:
+        json_str = json_path
+    raw_json = set_json_defaults(json_str, run_mmseqs, output_dir, max_template_date)
+    json_str = json.dumps(raw_json)
+
     fold_inputs = []
-    logging.info(
-        'Detected %s is an AlphaFold 3 JSON since the top-level is not a list.',
-        json_path,
-    )
-    # AlphaFold 3 JSON.
-    try:
-        fold_inputs.append(Input.from_json(json_str))
-    except ValueError as e:
-        raise ValueError(
-            f'Failed to load fold input from {json_path}. The JSON at'
-            f' {json_path} was detected to be an AlphaFold 3 JSON since the'
-            ' top-level is not a list.'
-        ) from e
+    if isinstance(raw_json, list):
+        # AlphaFold Server JSON.
+        logging.info(
+            'Detected %s is an AlphaFold Server JSON since the top-level is a'
+            ' list.',
+            json_path,
+        )
+
+        logging.info('Loading %d fold jobs from %s', len(raw_json), json_path)
+        for fold_job_idx, fold_job in enumerate(raw_json):
+            try:
+                fold_inputs.append(Input.from_alphafoldserver_fold_job(fold_job))
+            except ValueError as e:
+                raise ValueError(
+                    f'Failed to load fold job {fold_job_idx} from {json_path}. The JSON'
+                    f' at {json_path} was detected to be an AlphaFold Server JSON since'
+                    ' the top-level is a list.'
+                ) from e
+    else:
+        logging.info(
+            'Detected %s is an AlphaFold 3 JSON since the top-level is not a list.',
+            json_path,
+        )
+        # AlphaFold 3 JSON.
+        try:
+            fold_inputs.append(Input.from_json(json_str))
+        except ValueError as e:
+            raise ValueError(
+                f'Failed to load fold input from {json_path}. The JSON at'
+                f' {json_path} was detected to be an AlphaFold 3 JSON since the'
+                ' top-level is not a list.'
+            ) from e
 
     check_unique_sanitised_names(fold_inputs)
 

--- a/run/af3_utils.py
+++ b/run/af3_utils.py
@@ -57,11 +57,11 @@ def set_if_absent(d: Dict[str, Any], key: str, default_value: Any) -> None:
         d[key] = default_value
 
 
-def get_af3_args() -> Dict[str, Any]:
-    """Creates a parser for AF3 and returns a dictionary of the parsed args.
+def get_af3_parser() -> FileArgumentParser:
+    """Creates a parser for AF3.
 
     Returns:
-        Dict[str, Any]: Dictionary mapping argument key to argument value.
+        FileArgumentParser: Argument parser for AF3.
     """
     parser = FileArgumentParser(
         description="Runner script for AlphaFold3.",
@@ -158,8 +158,26 @@ def get_af3_args() -> Dict[str, Any]:
         " exactly that number of tokens. Defaults to"
         " '256,512,768,1024,1280,1536,2048,2560,3072,3584,4096,4608,5120'."
     )
+
+    return parser
+
+
+def get_af3_args(arg_file: Optional[str] = None) -> Dict[str, Any]:
+    """Reformats args and returns a dictionary parsed args.
+
+    If no arg_file is provided, then arguments are assumed to come from the
+    command line.
+
+    Returns:
+        Dict[str, Any]: Dictionary mapping argument key to argument value.
+    """
     
-    args = parser.parse_args()
+    # Get the parser and args
+    parser = get_af3_parser()
+    if arg_file is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args([f'@{arg_file}'])
     
     # Reformat some of the arguments
     args.run_inference = binary_to_bool(args.run_inference)

--- a/run/evopro_utils.py
+++ b/run/evopro_utils.py
@@ -1,0 +1,129 @@
+import json
+import pathlib
+import typing
+from typing import Sequence, Union, Callable, Tuple, Dict, Any
+from functools import partial
+import textwrap
+import jax
+
+from alphafold3.jax.attention import attention
+from alphafold3.model.diffusion import model as diffusion_model
+from alphafold3.model.post_processing import post_process_inference_result
+
+from af3_utils import load_fold_inputs_from_path, get_af3_args
+from run_af3 import ModelRunner, make_model_config, predict_structure
+
+
+def init_af3(proc_id: int, arg_file: str, lengths: Sequence[Union[int, Sequence[int]]]) -> Callable:
+    args_dict = get_af3_args(arg_file)
+
+    if args_dict['jax_compilation_cache_dir'] is not None:
+        jax.config.update(
+            'jax_compilation_cache_dir', args_dict['jax_compilation_cache_dir']
+        )
+
+    # Fail early on incompatible devices, only in init.
+    gpu_devices = jax.local_devices(backend='gpu')
+    if gpu_devices and float(gpu_devices[0].compute_capability) < 8.0:
+        raise ValueError(
+            'There are currently known unresolved numerical issues with using'
+            ' devices with compute capability less than 8.0. See '
+            ' https://github.com/google-deepmind/alphafold3/issues/59 for'
+            ' tracking.'
+        )
+
+    # Keep notice in init function, only print for proc_id 0.
+    if proc_id == 0:
+        notice = textwrap.wrap(
+            'Running AlphaFold 3. Please note that standard AlphaFold 3 model'
+            ' parameters are only available under terms of use provided at'
+            ' https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md.'
+            ' If you do not agree to these terms and are using AlphaFold 3 derived'
+            ' model parameters, cancel execution of AlphaFold 3 inference with'
+            ' CTRL-C, and do not use the model parameters.',
+            break_long_words=False,
+            break_on_hyphens=False,
+            width=80,
+        )
+        print('\n'.join(notice))
+
+    devices = jax.local_devices(backend='gpu')
+    model_runner = ModelRunner(
+        model_class=diffusion_model.Diffuser,
+        config=make_model_config(
+            flash_attention_implementation=typing.cast(
+                attention.Implementation, args_dict["flash_attention_implementation"]
+            ),
+            num_diffusion_samples=1,
+        ),
+        device=devices[0],
+        model_dir=pathlib.Path(args_dict["model_dir"]),
+    )
+
+    # Determine max length of sequences to use as bucket for model compilation
+    max_length = 0
+    for length in lengths:
+        if not isinstance(length, int):
+            length = max(length)
+        if length > max_length:
+            max_length = length
+    buckets = (max_length,)
+
+    # Use max_length to create a fake fold_input
+    json_dict = {
+        "name": "compilation_noodle",
+        "sequences": [{
+            "protein": {
+                "id": ["A"],
+                "sequence": "G" * max_length
+            }
+        }],
+        "modelSeeds": ['42']
+    }
+    json_str = json.dumps(json_dict)
+    fold_input = load_fold_inputs_from_path(json_str)[0]
+
+    # Make folding prediction
+    _ = model_runner.model_params
+    _ = predict_structure(
+        fold_input=fold_input,
+        model_runner=model_runner, 
+        buckets=buckets
+    )
+
+    return partial(run_af3, proc_id=proc_id, arg_file=arg_file, buckets=buckets, compiled_runner=model_runner)
+
+
+def run_af3(json_str: str, proc_id: int, arg_file: str, buckets: Tuple[int], compiled_runner: ModelRunner) -> Sequence[Dict[str, Any]]:
+    args_dict = get_af3_args(arg_file)
+    
+    if args_dict['jax_compilation_cache_dir'] is not None:
+        jax.config.update(
+            'jax_compilation_cache_dir', args_dict['jax_compilation_cache_dir']
+        )
+
+    # Convert json_str to fold_input and make prediction
+    fold_input = load_fold_inputs_from_path(json_str)[0]
+    all_inference_results = predict_structure(
+        fold_input=fold_input,
+        model_runner=compiled_runner, 
+        buckets=buckets
+    )
+
+    # Convert results into list of dict for output
+    processed_results = [
+        post_process_inference_result(result.inference_results[0])
+        for result in all_inference_results
+    ]
+    results_list = [
+        {
+            "seed": all_inference_results[i].seed,
+            "cif_str": result.cif.decode("utf-8"),
+            **json.loads(result.structure_confidence_summary_json.decode("utf-8")),
+            **json.loads(result.structure_full_data_json.decode("utf-8")),
+
+        }
+        for i, result in enumerate(processed_results)
+    ]
+
+    return results_list

--- a/run/evopro_utils.py
+++ b/run/evopro_utils.py
@@ -1,3 +1,4 @@
+import os
 import json
 import pathlib
 import typing
@@ -15,6 +16,10 @@ from run_af3 import ModelRunner, make_model_config, predict_structure
 
 
 def init_af3(proc_id: int, arg_file: str, lengths: Sequence[Union[int, Sequence[int]]]) -> Callable:
+    # Work around for a known XLA issue:
+    # https://github.com/google-deepmind/alphafold3/blob/main/docs/performance.md#compilation-time-workaround-with-xla-flags
+    os.environ["XLA_FLAGS"] = "--xla_gpu_enable_triton_gemm=false"
+    
     args_dict = get_af3_args(arg_file)
 
     if args_dict['jax_compilation_cache_dir'] is not None:

--- a/run/run_af3.py
+++ b/run/run_af3.py
@@ -523,10 +523,10 @@ def main(args_dict: Dict[str, Any]) -> None:
 
     # Make sure we can create the output directory before running anything.
     try:
-      os.makedirs(args_dict["output_dir"], exist_ok=True)
+        os.makedirs(args_dict["output_dir"], exist_ok=True)
     except OSError as e:
-      print(f'Failed to create output directory {args_dict["output_dir"]}: {e}')
-      raise
+        print(f'Failed to create output directory {args_dict["output_dir"]}: {e}')
+        raise
 
     if args_dict["input_dir"] is not None:
         fold_inputs = load_fold_inputs_from_dir(
@@ -600,24 +600,24 @@ def main(args_dict: Dict[str, Any]) -> None:
         data_pipeline_config = None
 
     if args_dict["run_inference"]:
-      devices = jax.local_devices(backend='gpu')
-      print(f'Found local devices: {devices}')
+        devices = jax.local_devices(backend='gpu')
+        print(f'Found local devices: {devices}')
 
-      print('Building model from scratch...')
-      model_runner = ModelRunner(
-          model_class=diffusion_model.Diffuser,
-          config=make_model_config(
-              flash_attention_implementation=typing.cast(
-                  attention.Implementation, args_dict["flash_attention_implementation"]
-              ),
-              num_diffusion_samples=args_dict["num_diffusion_samples"],
-          ),
-          device=devices[0],
-          model_dir=pathlib.Path(args_dict["model_dir"]),
-      )
+        print('Building model from scratch...')
+        model_runner = ModelRunner(
+            model_class=diffusion_model.Diffuser,
+            config=make_model_config(
+                flash_attention_implementation=typing.cast(
+                    attention.Implementation, args_dict["flash_attention_implementation"]
+                ),
+                num_diffusion_samples=args_dict["num_diffusion_samples"],
+            ),
+            device=devices[0],
+            model_dir=pathlib.Path(args_dict["model_dir"]),
+        )
     else:
-      print('Skipping running model inference.')
-      model_runner = None
+        print('Skipping running model inference.')
+        model_runner = None
 
     print(f'Processing {len(fold_inputs)} fold inputs.')
     for fold_input in fold_inputs:


### PR DESCRIPTION
This implements two new functions (`init_af3` and `run_af3`) in `evopro_utils.py` to be used by EvoPro. `init_af3` runs a fake input through AF3 to compile the model at a specific size so that we can avoid recompilation and returns a partial version of `run_af3`. `run_af3` just makes a prediction and returns the results as a list of dicts.

This also makes some fixes so that AlphaFold Server JSON format should be able to work. Default values are not updated in this format, but we should try to enable this eventually.